### PR TITLE
Avoid monorepo double clone on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Pre-built Docker images with Node.js, Python, or Go ready to go. Deploy any code
 
 How it works: deploy pulls a pre-built image, starts a container, syncs your repo, and runs `dev_startup.sh`. After that, your repo syncs every ~15 seconds and your dev server handles hot reload, while the health server on port 9090 keeps the container alive for debugging.
 
+Monorepos: set `GITHUB_REPO_FOLDER` to sync only a subfolder into `/workspaces/app`. The container keeps a git clone in `/tmp/monorepo-cache` and rsyncs the subfolder into the workspace (preserving common caches like `node_modules`).
+
 Deploy to DigitalOcean (uses `.do/deploy.template.yaml`):
 
 [![Deploy to DO](https://www.deploytodo.com/do-btn-blue.svg)](https://cloud.digitalocean.com/apps/new?repo=https://github.com/bikramkgupta/do-app-hot-reload-template/tree/main)

--- a/scripts/github-sync.sh
+++ b/scripts/github-sync.sh
@@ -398,8 +398,15 @@ main() {
         log_info "  - Branch: ${REPO_BRANCH:-auto-detect}"
     fi
 
-    # Initial sync (always runs on startup)
-    sync_repo
+    # Initial sync
+    # If startup.sh successfully performed the initial sync, it will create this marker.
+    # In that case, avoid doing an immediate duplicate sync here.
+    local startup_marker="/tmp/startup_sync_done"
+    if [ -f "$startup_marker" ]; then
+        log_info "Startup sync marker detected ($startup_marker). Skipping immediate initial sync."
+    else
+        sync_repo
+    fi
 
     # Continuous sync loop
     while true; do


### PR DESCRIPTION
### What\n- In monorepo mode (GITHUB_REPO_FOLDER set), startup now skips cloning into /workspaces/app and instead uses the monorepo cache + rsync to populate the workspace.\n- github-sync now skips its immediate initial sync when startup already synced successfully (marker: /tmp/startup_sync_done).\n\n### Why\nReduces cold start time by avoiding redundant clone/pull work in monorepo deployments, while keeping regular (single-repo) behavior unchanged.\n\n### Notes\n- Source files still mirror GitHub via rsync --delete, while preserving excluded caches like node_modules/.next.\n